### PR TITLE
Fix code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/electrum/base_crash_reporter.py
+++ b/electrum/base_crash_reporter.py
@@ -71,7 +71,9 @@ class BaseCrashReporter(Logger):
 
     def send_report(self, asyncio_loop, proxy, *, timeout=None) -> CrashReportResponse:
         # FIXME the caller needs to catch generic "Exception", as this method does not have a well-defined API...
-        if constants.net.GENESIS[-4:] not in ["4943", "e26f"] and ".electrum.org" in BaseCrashReporter.report_server:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(BaseCrashReporter.report_server)
+        if constants.net.GENESIS[-4:] not in ["4943", "e26f"] and not parsed_url.hostname.endswith(".electrum.org"):
             # Gah! Some kind of altcoin wants to send us crash reports.
             raise Exception(_("Missing report URL."))
         report = self.get_traceback_info()


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/electrum/security/code-scanning/5](https://github.com/Dargon789/electrum/security/code-scanning/5)

To fix the problem, we need to parse the URL and check its host value instead of using a substring check. This ensures that the check handles arbitrary subdomain sequences correctly and only allows valid URLs.

The best way to fix the problem without changing existing functionality is to use the `urlparse` function from the `urllib.parse` module to parse the `report_server` URL and then check if the hostname ends with ".electrum.org". This approach is more robust and secure.

We need to modify the `send_report` method in the `BaseCrashReporter` class to use `urlparse` for URL validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete URL substring sanitization vulnerability in crash reporting.